### PR TITLE
Add private event feature for gigs

### DIFF
--- a/db/migrate/20260429094639_add_private_event_to_gigs.rb
+++ b/db/migrate/20260429094639_add_private_event_to_gigs.rb
@@ -1,0 +1,5 @@
+class AddPrivateEventToGigs < ActiveRecord::Migration[7.0]
+  def change
+    add_column :gigs, :private_event, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_26_165312) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_29_094639) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -70,6 +70,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_26_165312) do
     t.string "name", null: false
     t.text "notes"
     t.date "performance_date"
+    t.boolean "private_event", default: false, null: false
     t.datetime "start_time"
     t.datetime "updated_at", null: false
     t.integer "venue_id"
@@ -205,8 +206,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_26_165312) do
     t.boolean "practice_state", default: false, null: false
     t.datetime "practice_state_updated_at", precision: nil
     t.bigint "song_id", null: false
-    t.string "transposed_key", limit: 10
-    t.integer "transposition_semitones", default: 0
     t.index ["band_id", "practice_state"], name: "index_songs_bands_on_band_id_and_practice_state"
     t.index ["band_id"], name: "index_songs_bands_on_band_id"
     t.index ["practice_state"], name: "index_songs_bands_on_practice_state"

--- a/lib/models/gig.rb
+++ b/lib/models/gig.rb
@@ -17,4 +17,5 @@ class Gig < ActiveRecord::Base
   scope :without_venue, -> { left_joins(:venue).where(venues: { id: nil }) }
   scope :chronological, -> { order(:performance_date) }
   scope :reverse_chronological, -> { order(performance_date: :desc) }
+  scope :public_events, -> { where(private_event: false) }
 end

--- a/lib/routes/gigs.rb
+++ b/lib/routes/gigs.rb
@@ -137,7 +137,8 @@ class Routes::Gigs < Sinatra::Base
       venue_id: params[:venue_id].presence,
       performance_date: params[:performance_date],
       start_time: start_time,
-      end_time: end_time
+      end_time: end_time,
+      private_event: params[:private_event] == '1'
     }
 
     gig = Gig.new(gig_params)
@@ -253,7 +254,8 @@ class Routes::Gigs < Sinatra::Base
       venue_id: params[:venue_id].presence,
       performance_date: params[:performance_date],
       start_time: start_time,
-      end_time: end_time
+      end_time: end_time,
+      private_event: params[:private_event] == '1'
     }
 
     if @gig.update(gig_params)

--- a/lib/routes/public_schedule.rb
+++ b/lib/routes/public_schedule.rb
@@ -56,17 +56,18 @@ class Routes::PublicSchedule < Sinatra::Base
         name: band.name
       },
       gigs: gigs.map { |gig|
-        {
+        entry = {
           id: gig.id,
           name: gig.name,
           performance_date: gig.performance_date.iso8601,
-          start_time: gig.start_time&.strftime('%H:%M'),
-          end_time: gig.end_time&.strftime('%H:%M'),
-          venue: gig.venue ? {
-            name: gig.venue.name,
-            location: gig.venue.location
-          } : nil
+          private_event: gig.private_event
         }
+        unless gig.private_event
+          entry[:start_time] = gig.start_time&.strftime('%H:%M')
+          entry[:end_time]   = gig.end_time&.strftime('%H:%M')
+          entry[:venue]      = gig.venue ? { name: gig.venue.name, location: gig.venue.location } : nil
+        end
+        entry
       }
     }.to_json
   end

--- a/spec/models/gig_spec.rb
+++ b/spec/models/gig_spec.rb
@@ -41,8 +41,16 @@ RSpec.describe Gig, type: :model do
       gig_c = create(:gig, name: 'C Set List')
       gig_a = create(:gig, name: 'A Set List')
       gig_b = create(:gig, name: 'B Set List')
-      
+
       expect(Gig.order(:name)).to eq([gig_a, gig_b, gig_c])
+    end
+
+    it 'filters public events only' do
+      public_gig = create(:gig, name: 'Public Gig', private_event: false)
+      private_gig = create(:gig, name: 'Private Gig', private_event: true)
+
+      expect(Gig.public_events).to include(public_gig)
+      expect(Gig.public_events).not_to include(private_gig)
     end
   end
 

--- a/spec/requests/gigs_spec.rb
+++ b/spec/requests/gigs_spec.rb
@@ -124,6 +124,43 @@ RSpec.describe 'Gigs API', type: :request do
       expect(last_response).to be_ok
       expect(last_response.body).to include("Performance date can't be blank")
     end
+
+    it 'creates a private gig when private_event is checked' do
+      login_as(user, band)
+      venue = create(:venue, band: band)
+      gig_params = {
+        name: 'Private Gig',
+        band_id: band.id,
+        venue_id: venue.id,
+        performance_date: '2024-12-25',
+        start_time: '20:00',
+        private_event: '1'
+      }
+
+      expect {
+        post '/gigs', gig_params
+      }.to change(Gig, :count).by(1)
+
+      new_gig = Gig.last
+      expect(new_gig.private_event).to be true
+      expect(new_gig.name).to eq('Private Gig')
+    end
+
+    it 'creates a public gig when private_event is not checked' do
+      login_as(user, band)
+      gig_params = {
+        name: 'Public Gig',
+        band_id: band.id,
+        performance_date: '2024-12-25'
+      }
+
+      expect {
+        post '/gigs', gig_params
+      }.to change(Gig, :count).by(1)
+
+      new_gig = Gig.last
+      expect(new_gig.private_event).to be false
+    end
   end
 
   describe 'GET /gigs/:id' do
@@ -229,6 +266,35 @@ RSpec.describe 'Gigs API', type: :request do
     it 'returns 404 for non-existent gig' do
       login_as(user, band)
       expect { put '/gigs/999', name: 'New Name' }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it 'can mark a gig as private' do
+      login_as(user, band)
+      gig = create(:gig, name: 'Public Gig', band: band, private_event: false)
+      update_params = {
+        name: gig.name,
+        performance_date: gig.performance_date,
+        private_event: '1'
+      }
+
+      put "/gigs/#{gig.id}", update_params
+
+      expect(last_response).to be_redirect
+      expect(gig.reload.private_event).to be true
+    end
+
+    it 'can mark a gig as public' do
+      login_as(user, band)
+      gig = create(:gig, name: 'Private Gig', band: band, private_event: true)
+      update_params = {
+        name: gig.name,
+        performance_date: gig.performance_date
+      }
+
+      put "/gigs/#{gig.id}", update_params
+
+      expect(last_response).to be_redirect
+      expect(gig.reload.private_event).to be false
     end
   end
 

--- a/spec/requests/public_schedule_spec.rb
+++ b/spec/requests/public_schedule_spec.rb
@@ -5,6 +5,12 @@ RSpec.describe 'Public Schedule Routes', type: :request do
   let(:band_with_gigs) { create(:band, name: 'Test Band', public_schedule_enabled: true) }
   let(:disabled_band) { create(:band, name: 'Private Band', public_schedule_enabled: false) }
 
+  around(:each) do |example|
+    freeze_time_for_testing do
+      example.run
+    end
+  end
+
   describe 'GET /schedule/:slug' do
     context 'when public schedule is enabled' do
       let!(:gig) { create(:gig, band: band_with_gigs, performance_date: Date.current + 7.days, start_time: Time.new(2025, 1, 1, 19, 0, 0)) }

--- a/spec/requests/public_schedule_spec.rb
+++ b/spec/requests/public_schedule_spec.rb
@@ -79,6 +79,35 @@ RSpec.describe 'Public Schedule Routes', type: :request do
         expect(last_response).to be_ok
         expect(last_response.body).to include('Venue-less Gig')
       end
+
+      it 'displays private events without time or location' do
+        private_venue = create(:venue, band: band_with_gigs, name: 'Secret Venue', location: 'Secret Location')
+        private_gig = create(:gig,
+          band: band_with_gigs,
+          name: 'Secret Party',
+          performance_date: Date.current + 5.days,
+          start_time: Time.new(2025, 1, 1, 20, 0, 0),
+          end_time: Time.new(2025, 1, 1, 23, 0, 0),
+          venue: private_venue,
+          private_event: true
+        )
+
+        get "/schedule/#{band_with_gigs.slug}"
+
+        expect(last_response).to be_ok
+        expect(last_response.body).to include('Private Event')
+        expect(last_response.body).not_to include('Secret Party')
+        expect(last_response.body).not_to include('Secret Venue')
+        expect(last_response.body).not_to include('Secret Location')
+      end
+
+      it 'displays public events with full details' do
+        get "/schedule/#{band_with_gigs.slug}"
+
+        expect(last_response.body).to include(gig.name)
+        expect(last_response.body).to include('Test Venue')
+        expect(last_response.body).to include('123 Main St')
+      end
     end
 
     context 'when public schedule is disabled' do
@@ -200,6 +229,41 @@ RSpec.describe 'Public Schedule Routes', type: :request do
 
         json = JSON.parse(last_response.body)
         expect(json['gigs']).to eq([])
+      end
+
+      it 'omits time and venue for private events' do
+        private_venue = create(:venue, band: band_with_gigs, name: 'Secret Venue', location: 'Secret Location')
+        private_gig = create(:gig,
+          band: band_with_gigs,
+          name: 'Private Party',
+          performance_date: Date.current + 5.days,
+          start_time: Time.new(2025, 1, 1, 20, 0, 0),
+          end_time: Time.new(2025, 1, 1, 23, 0, 0),
+          venue: private_venue,
+          private_event: true
+        )
+
+        get "/api/public/bands/#{band_with_gigs.slug}/schedule"
+
+        json = JSON.parse(last_response.body)
+        private_gig_json = json['gigs'].find { |g| g['name'] == 'Private Party' }
+
+        expect(private_gig_json['private_event']).to be true
+        expect(private_gig_json).not_to have_key('start_time')
+        expect(private_gig_json).not_to have_key('end_time')
+        expect(private_gig_json).not_to have_key('venue')
+      end
+
+      it 'includes time and venue for public events' do
+        get "/api/public/bands/#{band_with_gigs.slug}/schedule"
+
+        json = JSON.parse(last_response.body)
+        public_gig_json = json['gigs'].find { |g| g['name'] == 'First Gig' }
+
+        expect(public_gig_json['private_event']).to be false
+        expect(public_gig_json).to have_key('start_time')
+        expect(public_gig_json).to have_key('end_time')
+        expect(public_gig_json).to have_key('venue')
       end
     end
 

--- a/views/edit_gig.erb
+++ b/views/edit_gig.erb
@@ -3,7 +3,7 @@
         <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
         <path d="m18.5 2.5 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
     </svg>
-    Edit Gig: <%= @gig.name %>
+    Edit Gig: <%= @gig.name %><% if @gig.private_event %> <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: -3px;"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg><% end %>
 </h2>
 
 <%= erb :_errors %>
@@ -73,6 +73,14 @@
         <label for="gig_end_time">End Time</label>
         <input type="text" id="gig_end_time" name="end_time" placeholder="Select end time..." readonly
                data-utc="<%= @gig.end_time&.utc&.iso8601 %>">
+    </div>
+
+    <div class="form-group">
+        <label class="checkbox-label">
+            <input type="checkbox" id="gig_private_event" name="private_event" value="1" <%= 'checked' if @gig.private_event %>>
+            Private Event
+        </label>
+        <div class="form-help">Private events appear on the public schedule without time or location details.</div>
     </div>
 
     <div class="form-group">

--- a/views/edit_gig.erb
+++ b/views/edit_gig.erb
@@ -3,7 +3,7 @@
         <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
         <path d="m18.5 2.5 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
     </svg>
-    Edit Gig: <%= @gig.name %><% if @gig.private_event %> <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: -3px;"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg><% end %>
+    Edit Gig: <%= h(@gig.name) %><% if @gig.private_event %> <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: -3px;"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg><% end %>
 </h2>
 
 <%= erb :_errors %>

--- a/views/gigs.erb
+++ b/views/gigs.erb
@@ -74,7 +74,7 @@
 
                             <!-- Gig Name and Time Column -->
                             <div>
-                                <span style="font-weight: 600; font-size: 1.1em;"><%= set_list.name %><% if set_list.private_event %> <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: -2px;"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg><% end %></span>
+                                <span style="font-weight: 600; font-size: 1.1em;"><%= set_list.name %><% if set_list.private_event %> <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: -2px;" role="img" aria-label="Private event"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg><% end %></span>
                                 <% if set_list.start_time.present? %>
                                     <span style="font-weight: normal; color: #2d3748; font-size: 0.9em; margin-left: 8px;">
                                         - <span class="local-time" data-utc="<%= set_list.start_time.utc.iso8601 %>"><%= set_list.start_time.utc.strftime('%I:%M %p UTC') %></span>

--- a/views/gigs.erb
+++ b/views/gigs.erb
@@ -74,7 +74,7 @@
 
                             <!-- Gig Name and Time Column -->
                             <div>
-                                <span style="font-weight: 600; font-size: 1.1em;"><%= set_list.name %></span>
+                                <span style="font-weight: 600; font-size: 1.1em;"><%= set_list.name %><% if set_list.private_event %> <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: -2px;"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg><% end %></span>
                                 <% if set_list.start_time.present? %>
                                     <span style="font-weight: normal; color: #2d3748; font-size: 0.9em; margin-left: 8px;">
                                         - <span class="local-time" data-utc="<%= set_list.start_time.utc.iso8601 %>"><%= set_list.start_time.utc.strftime('%I:%M %p UTC') %></span>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -265,7 +265,33 @@
             border-color: #667eea;
             box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
         }
-        
+
+        .checkbox-label {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            font-weight: 600;
+            color: #4a5568;
+            font-size: 16px;
+            cursor: pointer;
+        }
+
+        .checkbox-label input[type="checkbox"] {
+            width: auto;
+            min-height: auto;
+            margin: 0;
+            accent-color: #667eea;
+            width: 18px;
+            height: 18px;
+            cursor: pointer;
+        }
+
+        .form-help {
+            margin-top: 6px;
+            font-size: 0.85rem;
+            color: #718096;
+        }
+
         .card {
             background: white;
             border-radius: 10px;

--- a/views/new_gig.erb
+++ b/views/new_gig.erb
@@ -96,6 +96,14 @@
     </div>
 
     <div class="form-group">
+        <label class="checkbox-label">
+            <input type="checkbox" id="gig_private_event" name="private_event" value="1">
+            Private Event
+        </label>
+        <div class="form-help">Private events appear on the public schedule without time or location details.</div>
+    </div>
+
+    <div class="form-group">
         <label for="gig_notes">Notes</label>
         <textarea id="gig_notes"
                   name="notes"

--- a/views/public_layout.erb
+++ b/views/public_layout.erb
@@ -142,6 +142,7 @@
             color: #94a3b8;
             font-size: 0.85rem;
         }
+
         
         .no-gigs {
             text-align: center;

--- a/views/public_schedule.erb
+++ b/views/public_schedule.erb
@@ -14,22 +14,24 @@
                         <div class="weekday"><%= gig.performance_date.strftime('%A') %></div>
                     </div>
                     <div class="gig-details">
-                        <div class="gig-name"><%= h(gig.name) %></div>
-                        <% if gig.start_time %>
-                            <div class="gig-time">
-                                🕐 <span class="local-time" data-utc="<%= gig.start_time.utc.iso8601 %>"><%= gig.start_time.utc.strftime('%I:%M %p UTC') %></span>
-                                <% if gig.end_time %>
-                                    - <span class="local-time" data-utc="<%= gig.end_time.utc.iso8601 %>"><%= gig.end_time.utc.strftime('%I:%M %p UTC') %></span>
-                                <% end %>
-                            </div>
-                        <% end %>
-                        <% if gig.venue %>
-                            <div class="gig-venue">
-                                📍 <span class="venue-name"><%= h(gig.venue.name) %></span>
-                                <% if gig.venue.location %>
-                                    <span class="venue-location"> — <%= h(gig.venue.location) %></span>
-                                <% end %>
-                            </div>
+                        <div class="gig-name"><%= gig.private_event ? 'Private Event' : h(gig.name) %></div>
+                        <% unless gig.private_event %>
+                            <% if gig.start_time %>
+                                <div class="gig-time">
+                                    🕐 <span class="local-time" data-utc="<%= gig.start_time.utc.iso8601 %>"><%= gig.start_time.utc.strftime('%I:%M %p UTC') %></span>
+                                    <% if gig.end_time %>
+                                        - <span class="local-time" data-utc="<%= gig.end_time.utc.iso8601 %>"><%= gig.end_time.utc.strftime('%I:%M %p UTC') %></span>
+                                    <% end %>
+                                </div>
+                            <% end %>
+                            <% if gig.venue %>
+                                <div class="gig-venue">
+                                    📍 <span class="venue-name"><%= h(gig.venue.name) %></span>
+                                    <% if gig.venue.location %>
+                                        <span class="venue-location"> — <%= h(gig.venue.location) %></span>
+                                    <% end %>
+                                </div>
+                            <% end %>
                         <% end %>
                     </div>
                 </div>

--- a/views/show_gig.erb
+++ b/views/show_gig.erb
@@ -17,7 +17,7 @@
             <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path>
             <rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect>
         </svg>
-        <%= @gig.name %>
+        <%= @gig.name %><% if @gig.private_event %> <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: -3px;"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg><% end %>
     </h2>
     <div style="display: flex; align-items: center; gap: 8px;">
         <a href="/gigs/<%= @gig.id %>/gig_mode" target="_blank" class="gig-mode-button" style="display: flex; align-items: center; justify-content: center; width: 44px; height: 44px; background: white; border: 1px solid #e2e8f0; border-radius: 8px; text-decoration: none; color: #4a5568; transition: all 0.2s;" onmouseover="this.style.backgroundColor='#667eea'; this.style.borderColor='#5a67d8'; this.style.color='white';" onmouseout="this.style.backgroundColor='white'; this.style.borderColor='#e2e8f0'; this.style.color='#4a5568';" title="Gig Mode - Offline Performance View">
@@ -110,6 +110,12 @@
                 <div class="detail-item">
                     <span class="detail-label">End Time:</span>
                     <span class="local-time" data-utc="<%= @gig.end_time.utc.iso8601 %>"><%= @gig.end_time.utc.strftime('%I:%M %p UTC') %></span>
+                </div>
+            <% end %>
+            <% if @gig.private_event %>
+                <div class="detail-item">
+                    <span class="detail-label">Visibility:</span>
+                    <span style="background: #f1f5f9; color: #64748b; font-size: 0.8rem; font-weight: 500; padding: 2px 10px; border-radius: 12px; border: 1px solid #cbd5e1;">Private Event</span>
                 </div>
             <% end %>
         </div>

--- a/views/show_gig.erb
+++ b/views/show_gig.erb
@@ -17,7 +17,7 @@
             <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path>
             <rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect>
         </svg>
-        <%= @gig.name %><% if @gig.private_event %> <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: -3px;"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg><% end %>
+        <%= h(@gig.name) %><% if @gig.private_event %> <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: -3px;"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg><% end %>
     </h2>
     <div style="display: flex; align-items: center; gap: 8px;">
         <a href="/gigs/<%= @gig.id %>/gig_mode" target="_blank" class="gig-mode-button" style="display: flex; align-items: center; justify-content: center; width: 44px; height: 44px; background: white; border: 1px solid #e2e8f0; border-radius: 8px; text-decoration: none; color: #4a5568; transition: all 0.2s;" onmouseover="this.style.backgroundColor='#667eea'; this.style.borderColor='#5a67d8'; this.style.color='white';" onmouseout="this.style.backgroundColor='white'; this.style.borderColor='#e2e8f0'; this.style.color='#4a5568';" title="Gig Mode - Offline Performance View">


### PR DESCRIPTION
## Summary
- Add `private_event` boolean column to gigs table with migration
- Add checkbox in gig create/edit forms to mark events as private  
- Display lock icon (🔒) next to private gig names in list, view, and edit screens
- Hide time and location for private events on public schedule page
- Show "Private Event" as title on public schedule instead of actual gig name
- Omit time/venue data from public schedule JSON API for private events

## Test Coverage
- Model scope test for `Gig.public_events` 
- Public schedule HTML view tests for private event display
- Public schedule JSON API tests for private event data omission
- Gig creation/update tests for `private_event` flag toggling

## Screenshots
Private gigs show a lock icon in internal views and are hidden from public schedules while still appearing on the calendar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to mark gigs as private events, hiding specific timing and venue details from the public schedule
  * Private events display as "Private Event" labels with lock icons for clear visual identification across the platform

* **Style**
  * Enhanced checkbox and form help text styling

* **Tests**
  * Added comprehensive test coverage for private event creation, updates, and public display behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->